### PR TITLE
fix qTable loader position, fix qTable initial loading

### DIFF
--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -17,7 +17,7 @@
       :style="loadingWrapperClass"
     >
       <q-scrollbar
-        v-if="rows.length"
+        v-if="rows.length || initialLoading"
         wrap-class="q-table__scroll-wrapper"
         theme="secondary"
       >
@@ -414,7 +414,8 @@ export default {
       loaderRow: null,
       wrapperClass: '',
       checkedRows: [],
-      sort: this.defaultSort
+      sort: this.defaultSort,
+      initialLoading: true
     };
   },
 
@@ -516,6 +517,8 @@ export default {
               updatedRow
             );
           }
+
+          if (this.initialLoading) this.initialLoading = false;
 
           return updatedRow;
         });

--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -17,7 +17,7 @@
       :style="loadingWrapperClass"
     >
       <q-scrollbar
-        v-if="rows.length || initialLoading"
+        v-if="rows.length"
         wrap-class="q-table__scroll-wrapper"
         theme="secondary"
       >
@@ -414,8 +414,7 @@ export default {
       loaderRow: null,
       wrapperClass: '',
       checkedRows: [],
-      sort: this.defaultSort,
-      initialLoading: true
+      sort: this.defaultSort
     };
   },
 
@@ -517,8 +516,6 @@ export default {
               updatedRow
             );
           }
-
-          if (this.initialLoading) this.initialLoading = false;
 
           return updatedRow;
         });

--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -3,7 +3,7 @@
     <div
       v-if="isLeftShadowShown"
       class="q-table__column-shadow q-table__column-shadow_left"
-      :style="fixedWidth({ key: 'shadow' })"
+      :style="getCellWidth({ key: 'shadow' })"
     />
 
     <div
@@ -69,7 +69,7 @@
                 <th
                   v-for="(column, index) in columns"
                   :key="index"
-                  :style="fixedWidth(column)"
+                  :style="getCellWidth(column)"
                   :class="getCellClass(column)"
                   class="q-table__header-cell"
                   @click="handleHeaderClick(column)"
@@ -168,7 +168,7 @@
                 <td
                   v-for="(column, index) in columns"
                   :key="index"
-                  :style="fixedWidth(column)"
+                  :style="getCellWidth(column)"
                   :class="getCellClass(column)"
                   class="q-table__cell q-table__total-cell"
                 >
@@ -786,8 +786,12 @@ export default {
       return sortableClass;
     },
 
-    fixedWidth(column) {
+    getCellWidth(column) {
       const style = {};
+
+      if (column.width) {
+        style.width = `${column.width}px`;
+      }
 
       if (column.minWidth) {
         style.minWidth = `${column.minWidth}px`;

--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -17,7 +17,7 @@
       :style="loadingWrapperClass"
     >
       <q-scrollbar
-        v-if="rows.length"
+        v-if="rows.length || isLoading"
         wrap-class="q-table__scroll-wrapper"
         theme="secondary"
       >

--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -14,10 +14,8 @@
     <div
       ref="loaderWrapper"
       class="q-table__loading-wrapper"
-      :style="loadingWrapperClass"
     >
       <q-scrollbar
-        v-if="rows.length || isLoading"
         wrap-class="q-table__scroll-wrapper"
         theme="secondary"
       >
@@ -25,6 +23,7 @@
           ref="tableWrapper"
           class="q-table__wrapper"
           :class="wrapperClass"
+          :style="loadingWrapperClass"
         >
           <div
             v-if="isLoading || !isLoadingAnimationComplete"
@@ -45,6 +44,7 @@
           </template>
 
           <table
+            v-if="rows.length"
             ref="QTable"
             class="q-table__table"
             :class="tableClasses"
@@ -234,18 +234,18 @@
               </template>
             </tbody>
           </table>
+
+          <div
+            v-else
+            class="q-table__empty"
+          >
+            <div class="q-table__empty-image" />
+            <div class="q-table__empty-text">
+              {{ emptyText || $t('QTable.noData') }}
+            </div>
+          </div>
         </div>
       </q-scrollbar>
-
-      <div
-        v-else
-        class="q-table__empty"
-      >
-        <div class="q-table__empty-image" />
-        <div class="q-table__empty-text">
-          {{ emptyText || $t('QTable.noData') }}
-        </div>
-      </div>
     </div>
   </div>
 </template>
@@ -258,6 +258,7 @@ import withQTableRow from './hocs/withQTableRow';
 
 const RowHoc = withQTableRow(QTableRow);
 const shadowDropOffset = 3;
+const MIN_BLANK_TABLE_HEIGHT = 228;
 
 export default {
   name: 'QTable',
@@ -492,12 +493,12 @@ export default {
       setTimeout(() => {
         this.loaderWrapperHeight = this.$refs.QTable
           ? this.$refs.QTable.clientHeight + shadowDropOffset
-          : 0;
+          : MIN_BLANK_TABLE_HEIGHT;
 
         setTimeout(() => {
           this.isLoadingAnimationComplete = true;
-        }, this.timer * 200);
-      }, 100);
+        }, 200);
+      }, this.timer * 300);
     },
     rows: {
       handler(rows) {
@@ -536,7 +537,7 @@ export default {
 
     this.loaderWrapperHeight = this.$refs.QTable
       ? this.$refs.QTable.clientHeight + shadowDropOffset
-      : 0;
+      : MIN_BLANK_TABLE_HEIGHT;
   },
 
   mounted() {
@@ -547,7 +548,7 @@ export default {
 
     const wrapper = this.$refs?.tableWrapper ?? null;
 
-    if (wrapper) {
+    if (wrapper && this.$refs.QTable) {
       if (wrapper.offsetWidth < this.$refs.QTable.offsetWidth) {
         this.wrapperClass = 'q-table__wrapper_scrollable';
       }

--- a/src/qComponents/QTable/src/components/QTableRow/index.vue
+++ b/src/qComponents/QTable/src/components/QTableRow/index.vue
@@ -245,8 +245,12 @@ export default {
         maxWidth: maxWidth ? `${maxWidth}px` : ''
       };
     },
-    getCellStyle(key, columnIndex) {
+    getCellStyle(key, columnIndex, width) {
       const style = {};
+
+      if (width) {
+        style.width = `${width}px`;
+      }
 
       if (
         columnIndex === 0 &&

--- a/src/qComponents/QTable/src/q-table.scss
+++ b/src/qComponents/QTable/src/q-table.scss
@@ -101,6 +101,7 @@
     justify-content: center;
     width: 100%;
     height: 100%;
+    min-height: 192px;
     padding-top: 64px;
     background-color: var(--color-tertiary-gray-light);
     opacity: 0;

--- a/src/qComponents/QTable/src/q-table.scss
+++ b/src/qComponents/QTable/src/q-table.scss
@@ -88,7 +88,6 @@
 
   &__loading-wrapper {
     height: 100%;
-    min-height: 192px;
     overflow: hidden;
   }
 
@@ -101,11 +100,11 @@
     justify-content: center;
     width: 100%;
     height: 100%;
-    min-height: 192px;
-    padding-top: 64px;
+    min-height: 115px;
+    padding-top: 25px;
     background-color: var(--color-tertiary-gray-light);
     opacity: 0;
-    transition: height 0.2s, background-color 0.5s, opacity 0.2s 0.4s;
+    transition: height 0.2s, background-color 0.5s, opacity 0.2s 0.6s;
 
     &-circle {
       width: 64px;
@@ -142,6 +141,7 @@
     &_is-loading {
       z-index: 10;
       opacity: 1;
+      transition: opacity 0.2s 0.1s;
     }
   }
 

--- a/src/qComponents/QTable/src/q-table.scss
+++ b/src/qComponents/QTable/src/q-table.scss
@@ -88,6 +88,7 @@
 
   &__loading-wrapper {
     height: 100%;
+    min-height: 192px;
     overflow: hidden;
   }
 
@@ -98,9 +99,9 @@
     z-index: 10;
     display: flex;
     justify-content: center;
-    align-items: center;
     width: 100%;
     height: 100%;
+    padding-top: 64px;
     background-color: var(--color-tertiary-gray-light);
     opacity: 0;
     transition: height 0.2s, background-color 0.5s, opacity 0.2s 0.4s;
@@ -161,6 +162,7 @@
     overflow: hidden;
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-base);
+    vertical-align: top;
     color: var(--color-primary-black);
     white-space: nowrap;
 


### PR DESCRIPTION
1. In initial state shows "empty table" image - fixed
2. When table larger than screen loader circle isn't visible - fixed
3. Fixed table's header vertical aligning