### PR TITLE
Fix query and values disappearance in QSelect multiply mode

### DIFF
--- a/src/qComponents/QSelect/src/QSelect.vue
+++ b/src/qComponents/QSelect/src/QSelect.vue
@@ -346,6 +346,7 @@ export default {
     options() {
       this.setSelected();
     },
+
     value(val, oldVal) {
       this.setSelected();
 
@@ -472,6 +473,7 @@ export default {
 
     hidePopper() {
       this.isDropdownShown = false;
+      this.query = '';
 
       if (!this.popper) return;
 
@@ -506,7 +508,18 @@ export default {
         const result = [];
         if (Array.isArray(this.value)) {
           this.value.forEach(value => {
-            result.push(this.getOption(value));
+            const option = this.getOption(value);
+
+            if (option) {
+              result.push(option);
+              return;
+            }
+
+            const keyByValueKey = get(value, this.valueKey);
+            const cachedOption = this.selected.find(
+              ({ key }) => key === keyByValueKey
+            );
+            if (cachedOption) result.push(cachedOption);
           });
         }
 


### PR DESCRIPTION
1) Reset query on hidePopper
2) Use options from this.selected if new this.options do not have such values
