### PR TITLE
[QSelect] Fix single tag width

### DIFF
--- a/src/qComponents/QSelect/src/q-select-tags.scss
+++ b/src/qComponents/QSelect/src/q-select-tags.scss
@@ -21,7 +21,7 @@
   &.q-select-tags_collapse-tags {
     flex-wrap: nowrap;
 
-    .q-tag:last-of-type {
+    .q-tag + .q-tag {
       flex-shrink: 0;
     }
   }

--- a/src/qComponents/QTag/src/q-tag.scss
+++ b/src/qComponents/QTag/src/q-tag.scss
@@ -27,7 +27,7 @@
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    word-break: break-word;
+    word-break: break-all;
   }
 
   &__close {


### PR DESCRIPTION
before
<img width="430" alt="изображение" src="https://user-images.githubusercontent.com/8091902/105742286-5dc0c600-5f4c-11eb-9a5e-8e8c843c5936.png">

after
<img width="366" alt="изображение" src="https://user-images.githubusercontent.com/8091902/105742460-96609f80-5f4c-11eb-8e0f-bda450a6a1dd.png">
