### PR TITLE
[QBreadcrumbs] Fix color of single crumb

### DIFF
--- a/src/qComponents/QBreadcrumbs/src/q-breadcrumbs.scss
+++ b/src/qComponents/QBreadcrumbs/src/q-breadcrumbs.scss
@@ -26,6 +26,10 @@
       text-decoration: underline;
     }
 
+    &_last:first-child {
+      color: var(--color-primary-black);
+    }
+
     &_exact-active:not(:first-child),
     &_last:not(:first-child) {
       font-weight: var(--font-weight-bold);


### PR DESCRIPTION
Before the fix, the crumb was primary-blue, which is not correct because it is not interactive